### PR TITLE
Another collecting-hash-table mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ If the key doesn't yet exist, places the value in a new list.
 
 :push - Like append, but sticks things on the other end.
 
+:concatenate - Assumes that both new and existing values are lists, storing the
+concatenation of them under the key.
+
 Obviously, not all modes are compatible with each other. Collecting-hash-table
 makes no attempt to save you from intermingling them.
 

--- a/README.md
+++ b/README.md
@@ -74,12 +74,13 @@ With-keys is the hash table equivalent of with-slots.
 "Hi, andrew in SANTA CRUZ!"
 ```
 
-The first parameter is a list of keys that with-keys will reference in the hash
-table provided in the second parameter. With-keys will attempt to convert each
-key into a symbol, binding the hash table value to it during body execution.
+The first parameter is a list of keys. With-keys will reference the keys in the hash
+table provided as the second parameter. With-keys will attempt to convert each
+key into a symbol in the current package, binding the hash table value to it
+during body execution.
 String keys are upcased before conversion to symbols.
 
-If you don't want with-keys to guess at a symbol for a key, supply a list -
+If you don't want with-keys to guess at a symbol, supply a list -
  (*symbol key*) - in place of the key, as in (loc "location") above.
 
 Collecting-hash-table
@@ -98,9 +99,10 @@ This code collects words into bins based on their length:
     (let ((word (format nil "~r" i)))
       (collect (length word) word)))
 ```
-Result: <hash table: 5 => ("three" "seven" "eight")
-                     3 => ("one" "two" "six")
-                     4 => ("zero" "four" "five" "nine")>
+
+Result: &lt;hash table: 5 =&gt; ("three" "seven" "eight")
+                     3 =&gt; ("one" "two" "six")
+                     4 =&gt; ("zero" "four" "five" "nine")&gt;
 
 The mode can be set in the parameters section of collecting-hash-table with the
 :mode keyword. The :mode keyword can also be passed to individual collect calls.

--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ With-keys
 With-keys is the hash table equivalent of with-slots.
 
 ```common-lisp
+(defvar ht (hash ("name" "andrew") ("location" "santa cruz")))
 (with-keys
    ("name" (loc "location"))
-    (hash ("name" "andrew") ("location" "santa cruz"))
+    ht
     (setf loc (string-upcase loc))
   (format nil "Hi, ~a in ~a!" name loc))
 "Hi, andrew in SANTA CRUZ!"

--- a/more-hash-util.lisp
+++ b/more-hash-util.lisp
@@ -68,6 +68,9 @@ If you don't want with-keys to guess at a symbol for a key, supply a list -
        (:push (list
                (lambda (e n) (cons n e))
                (lambda (v) (list v))))
+       (:concatenate (list
+                      (lambda (e n) (concatenate 'list e n))
+                      (lambda (v) v)))
        (otherwise (error "Mode not found"))))
     (function
      (list
@@ -108,8 +111,8 @@ This code collects words into bins based on their length:
   this option at the same time as :test will result in an error.
 
   :mode - Set the default mode for the collect function. Modes are :replace :keep
-  :tally :sum :append :push or a function that will be applied in a reduce-like
-  fashion to the existing and new values of a key."
+  :tally :sum :append :push :concatenate or a function that will be applied in a
+  reduce-like fashion to the existing and new values of a key."
   (and test-set-p existing
        (error "Can't set test when reusing an existing hash table"))
   (let ((fill (gensym))

--- a/more-hash-util.lisp
+++ b/more-hash-util.lisp
@@ -53,22 +53,22 @@ If you don't want with-keys to guess at a symbol for a key, supply a list -
        (:replace (list
                   (lambda (e n) (declare (ignore e)) n)
                   (lambda (v) v)))
-        (:keep (list
-                (lambda (e n) (declare (ignore n)) e)
-                (lambda (v) v)))
-        (:tally (list
-                 (lambda (e n) (declare (ignore n)) (1+ e))
-                 (lambda (v) (declare (ignore v)) 1)))
-        (:sum (list
-               (lambda (e n) (+ e n))
+       (:keep (list
+               (lambda (e n) (declare (ignore n)) e)
                (lambda (v) v)))
-        (:append (list
-                  (lambda (e n) (nconc e (list n)))
-                  (lambda (v) (list v))))
-        (:push (list
-                (lambda (e n) (cons n e))
-                (lambda (v) (list v))))
-        (otherwise (error "Mode not found"))))
+       (:tally (list
+                (lambda (e n) (declare (ignore n)) (1+ e))
+                (lambda (v) (declare (ignore v)) 1)))
+       (:sum (list
+              (lambda (e n) (+ e n))
+              (lambda (v) v)))
+       (:append (list
+                 (lambda (e n) (nconc e (list n)))
+                 (lambda (v) (list v))))
+       (:push (list
+               (lambda (e n) (cons n e))
+               (lambda (v) (list v))))
+       (otherwise (error "Mode not found"))))
     (function
      (list
       (lambda (e n) (funcall mode e n))
@@ -79,7 +79,7 @@ If you don't want with-keys to guess at a symbol for a key, supply a list -
 
 (defmacro collecting-hash-table ((&key (test '(function eql) test-set-p)
                                     existing (mode :append)) &body body)
-   "A collection macro that builds and outputs a hash table. To add to the hash
+  "A collection macro that builds and outputs a hash table. To add to the hash
 table, call the collect function with a key and a value from within the scope
 of the collecting-hash-table macro. The value will be inserted or combined with
 existing values according to the specified mode.
@@ -91,25 +91,25 @@ This code collects words into bins based on their length:
   (dotimes (i 10)
     (let ((word (format nil \"~r\" i)))
       (collect (length word) word)))
-```
-Result: <hash table: 5 => (\"three\" \"seven\" \"eight\")
-                     3 => (\"one\" \"two\" \"six\")
-                     4 => (\"zero\" \"four\" \"five\" \"nine\")>
+  ```
+  Result: <hash table: 5 => (\"three\" \"seven\" \"eight\")
+                       3 => (\"one\" \"two\" \"six\")
+                       4 => (\"zero\" \"four\" \"five\" \"nine\")>
 
-The mode can be set in the parameters section of collecting-hash-table with the
-:mode keyword. The :mode keyword can also be passed to individual collect calls.
+  The mode can be set in the parameters section of collecting-hash-table with the
+  :mode keyword. The :mode keyword can also be passed to individual collect calls.
 
-Keyword parameters:
+  Keyword parameters:
 
-:test - Test function parameter passed to make-hash-table when creating a new
-hash table
+  :test - Test function parameter passed to make-hash-table when creating a new
+  hash table
 
-:existing - Pass an existing hash table to the macro for modification. Using
-this option at the same time as :test will result in an error.
+  :existing - Pass an existing hash table to the macro for modification. Using
+  this option at the same time as :test will result in an error.
 
-:mode - Set the default mode for the collect function. Modes are :replace :keep
-:tally :sum :append :push or a function that will be applied in a reduce-like
-fashion to the existing and new values of a key."
+  :mode - Set the default mode for the collect function. Modes are :replace :keep
+  :tally :sum :append :push or a function that will be applied in a reduce-like
+  fashion to the existing and new values of a key."
   (and test-set-p existing
        (error "Can't set test when reusing an existing hash table"))
   (let ((fill (gensym))
@@ -198,4 +198,3 @@ accumulated to each key as by a reduce of the function."
        (push v stor))
      hsh)
     (nreverse stor)))
-


### PR DESCRIPTION
Hi Andrew,

I cleaned up a few things and added a :concatenate mode for the collecting macro.

I've also got a do-hash-table macro that I didn't include. It's very nearly the same thing as maphash, just a little less verbose in use. I'm unsure about cluttering the namespace with it. Thoughts?

Ben