### PR TITLE
Implemented hash-get/extend

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,41 @@ You can also do nested hashes:
 
 This saves a lot of typing =].
 
+Hash-get/extend
+---------------
+
+Hash-get will throw an error if a portion of the hash tree is missing:
+
+```common-lisp
+(defvar *hash* (hash-create `((a ,(hash-create `((b ,(hash))))))))
+(hash-get *hash* '(a b c d e)) => The value NIL is not of type HASH-TABLE.
+```
+
+For alternate behavior, use Hash-get/extend:
+
+```common-lisp
+(hash-get/extend *hash* '(a b c d e))
+NIL
+(C D E)
+```
+
+Used in its setf form, hash-get/extend will pad out the missing nodes of the
+tree with hash tables, placing the setf value in the final table. By default
+the padding will consist of calls to make-hash-table without arguments. If you
+wish to use custom hash table configurations, supply a function that returns a
+hash table as the third argument to hash-get/extend:
+
+```common-lisp
+(setf (hash-get/extend *hash*
+                       '(a b f g h)
+                       (lambda () (make-hash-table :test 'equal)))
+      'value)
+```
+
+Hash-get/extend does not support the addition of sequences or arrays to the
+tree. They must be added manually. Numerical indices in the extension
+portion of the path will result in an error.
+
 With-keys
 ---------
 
@@ -160,11 +195,4 @@ plists: alist->plist, plist->alist, alist->hash, plist->hash, hash->alist, and h
 
 The alist->hash and plist->hash take the same :existing and :mode keywords that
 collecting-hash-table takes.
-
-
-
-
-
-
-
 

--- a/hash-util.lisp
+++ b/hash-util.lisp
@@ -144,7 +144,7 @@
    pad out a missing tree with new hash tables, placing the value in the
    bottom-most hash table."
   (multiple-value-bind (value leftover) (%hget-core obj path)
-    (if leftovers
+    (if leftover
         (values nil leftover)
         value)))
 
@@ -160,6 +160,8 @@
    Hget/extend does not support the addition of sequences or arrays to the tree.
    They must be added manually. Numerical indices in the extension portion of
    the path will result in an error."
+  (unless (functionp new-hash-func)
+    (error "New-hash-func argument is a non-function"))
   (let ((path (if (listp path) path (list path))))
     (multiple-value-bind (value leftover) (%hget-core obj path)
       (if leftover

--- a/hash-util.lisp
+++ b/hash-util.lisp
@@ -137,6 +137,7 @@
        (hget/extend *hash* '(:a :b :c :d :e))
 
    will return the values NIL and (:C :D :E).
+
    On its own, hget/extend doesn't extend anything, used with setf, it will
    pad out a missing tree with new hash tables, placing the value in the
    bottom-most hash table."
@@ -151,8 +152,8 @@
    sequences that contains the branches in path. If any nodes are absent, they
    will be padded out before setting the value in the bottom-most node. By
    default the padding consists of calls to make-hash-table with no arguments.
-   To customize the new hash tables, supply a function that returns a custom
-   hash table in the optional new-hash-func parameter.
+   An alternate hash table constructor function can be supplied with the
+   new-hash-func argument.
 
    Hget/extend does not support the addition of sequences or arrays to the tree.
    They must be added manually. Numerical indices in the extension portion of
@@ -169,6 +170,8 @@
             (setf (gethash (car (last leftover)) current) val))
           (setf (hget obj path) val)))))
 
+(setf (fdefinition 'hash-get) #'hget)
+(setf (fdefinition 'hash-get/extend) #'hget/extend)
 
 (defun hash-copy (hash &key (test #'equal))
   "Performs a shallow (non-recursive) copy of a hash table."

--- a/hash-util.lisp
+++ b/hash-util.lisp
@@ -56,7 +56,9 @@
            :plist->hash
            :hash->alist
            :hash->plist
-           :hget/extend)
+           :hget/extend
+           :hash-get
+           :hash-get/extend)
   (:nicknames :hu))
 (in-package :cl-hash-util)
 
@@ -133,7 +135,7 @@
    missing. Instead, it returns nil as the first value and the unmatched
    portion of the path as the second value.
 
-       (defvar *hash* (hash (list :a (hash '(:b (hash))))))
+       (defvar *hash* (hash-create `((:a ,(hash-create `((:b ,(hash))))))))
        (hget/extend *hash* '(:a :b :c :d :e))
 
    will return the values NIL and (:C :D :E).


### PR DESCRIPTION
A version of hash-get/hget for working with hash trees where some of the tree may not be filled out yet.