### PR TITLE
cl-hash-util.asd: Specify loading order

### DIFF
--- a/cl-hash-util.asd
+++ b/cl-hash-util.asd
@@ -3,5 +3,6 @@
   :license "MIT"
   :version "0.1.7"
   :description "A simple and natural wrapper around Common Lisp's hash functionality."
+  :serial t
   :components ((:file "hash-util")
                (:file "more-hash-util")))


### PR DESCRIPTION
Otherwise operations can assume the order they want. It appears to be this is [not only a theoretical issue](http://log.irc.tymoon.eu/freenode/lisp?around=2016-10-17T23:45:02&types=mnaot#1476747902)