### PR TITLE
Feat: hash-merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,19 @@ plists: alist->plist, plist->alist, alist->hash, plist->hash, hash->alist, and h
 The alist->hash and plist->hash take the same :existing and :mode keywords that
 collecting-hash-table takes.
 
+Merging hash-tables
+-------------------
+
+The function `hash-merge` returns a merged hash-table.
+If a key occurs more than one time, the first key value is used
+and subsequent key values are discarded.
+For keeping the last value of a key, reverse the hash-table order.
+
+```common-lisp
+(hash-merge (hash-create (list (list "first" 1) (list "second" 2)))
+            (hash-create (list (list "first" 234234) (list "third" 235346))))
+;; Contents:
+;; "first" 1
+;; "second" 2
+;; "third" 235346
+```

--- a/tests.lisp
+++ b/tests.lisp
@@ -31,3 +31,16 @@
   (is (equal '(b c d) (nth-value 2 (hget ht '(b c d)))))
   (is (= 5 (setf (hget ht '(b c d) :fill-func #'make-hash-table) 5)))
   (is (= 5 (hget ht '(b c d)))))
+
+(test hash-merge
+  (let* ((hash-table-1
+	  (hash-create (list (list "first" 1) (list "second" 2))))
+	(hash-table-2
+	  (hash-create (list (list "first" 234234) (list "third" 235346))))
+	 (merged-hash-table
+	   (hash-merge hash-table-1 hash-table-2))
+	 (reverse-merged-hash-table
+	   (hash-merge hash-table-2 hash-table-1)))
+    (is (= 3 (hash-table-count merged-hash-table)))
+    (is (= 1 (gethash "first" merged-hash-table)))
+    (is (= 234234 (gethash "first" reverse-merged-hash-table)))))


### PR DESCRIPTION
The function `hash-merge` returns a merged hash-table. If a key occurs more than one time, the first key value is used and subsequent key values are discarded.
For keeping the last value of a key, reverse the hash-table order.

See #8 